### PR TITLE
fix: line-height by changing 'space-y-2' to 'leading-6' on question card

### DIFF
--- a/src/components/quiz/question-card.tsx
+++ b/src/components/quiz/question-card.tsx
@@ -132,7 +132,7 @@ export function QuestionCard({
     <Card>
       <CardHeader>
         <ScrollArea className="w-full min-w-0">
-          <CardTitle className="text-md mb-1 font-medium">
+          <CardTitle className="mb-1 leading-6 font-medium">
             <Markdown
               remarkPlugins={[remarkMath]}
               rehypePlugins={[rehypeKatex]}


### PR DESCRIPTION
Remove ‘space-y-2’, which does not work, and replace it with ‘text-md’.
Before:
<img width="818" height="313" alt="image" src="https://github.com/user-attachments/assets/83ccab9a-07f7-4ca6-b2a4-4392b3165b07" />

After:
<img width="809" height="348" alt="image" src="https://github.com/user-attachments/assets/8074ead2-7aca-45d9-84c1-75c7d374466a" />
