### PR TITLE
fix: fix logo offset on safari

### DIFF
--- a/src/components/app-logo.tsx
+++ b/src/components/app-logo.tsx
@@ -7,11 +7,11 @@ import Logo from "@/assets/logo.svg";
 export function AppLogo(): React.JSX.Element {
   return (
     <>
-      <Image src={Logo} alt="Logo" className="h-9 w-fit dark:hidden" />
+      <Image src={Logo} alt="Logo" className="h-9 w-auto dark:hidden" />
       <Image
         src={LogoDark}
         alt="Logo"
-        className="hidden h-9 w-fit dark:block"
+        className="hidden h-9 w-auto dark:block"
       />
     </>
   );


### PR DESCRIPTION
Fixed logo offset. Tested on macOS safari and Amelka's iPad