### PR TITLE
fix: harden maintenance recovery handling

### DIFF
--- a/src/__tests__/maintenance.spec.tsx
+++ b/src/__tests__/maintenance.spec.tsx
@@ -60,6 +60,18 @@ it.each([false, true])(
   },
 );
 
+it("keeps the server-side 503 response on the existing error path", async () => {
+  vi.stubGlobal("window", null);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response("unavailable", { status: 503 })),
+  );
+
+  await expect(new ProbeService("http://test.local").request()).rejects.toThrow(
+    "503",
+  );
+});
+
 it.each([500, 502, 503, 504, 429, 200])(
   "reloads only after a healthy status response: %i",
   async (status) => {

--- a/src/__tests__/maintenance.spec.tsx
+++ b/src/__tests__/maintenance.spec.tsx
@@ -60,33 +60,6 @@ it.each([false, true])(
   },
 );
 
-it.each([
-  "Failed to fetch",
-  "fetch failed",
-  "Load failed",
-  "Network error",
-  "NetworkError when attempting to fetch resource.",
-])(
-  "rejects network failures without entering maintenance: %s",
-  async (message) => {
-    render(
-      <MaintenanceWrapper>
-        <p>Quiz content</p>
-      </MaintenanceWrapper>,
-    );
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError(message)));
-
-    await act(async () => {
-      await expect(
-        new ProbeService("http://test.local").request(),
-      ).rejects.toThrow(message);
-    });
-
-    expect(screen.getByText("Quiz content")).toBeVisible();
-    expect(screen.queryByText("Przerwa techniczna")).not.toBeInTheDocument();
-  },
-);
-
 it.each([500, 502, 503, 504, 429, 200])(
   "reloads only after a healthy status response: %i",
   async (status) => {

--- a/src/__tests__/maintenance.spec.tsx
+++ b/src/__tests__/maintenance.spec.tsx
@@ -60,6 +60,33 @@ it.each([false, true])(
   },
 );
 
+it.each([
+  "Failed to fetch",
+  "fetch failed",
+  "Load failed",
+  "Network error",
+  "NetworkError when attempting to fetch resource.",
+])(
+  "rejects network failures without entering maintenance: %s",
+  async (message) => {
+    render(
+      <MaintenanceWrapper>
+        <p>Quiz content</p>
+      </MaintenanceWrapper>,
+    );
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError(message)));
+
+    await act(async () => {
+      await expect(
+        new ProbeService("http://test.local").request(),
+      ).rejects.toThrow(message);
+    });
+
+    expect(screen.getByText("Quiz content")).toBeVisible();
+    expect(screen.queryByText("Przerwa techniczna")).not.toBeInTheDocument();
+  },
+);
+
 it.each([500, 502, 503, 504, 429, 200])(
   "reloads only after a healthy status response: %i",
   async (status) => {

--- a/src/components/maintenance.tsx
+++ b/src/components/maintenance.tsx
@@ -21,8 +21,9 @@ function MaintenanceOverlay() {
         if (response.ok) {
           window.location.reload();
         }
-      } catch {
-        // Ignore polling errors while the backend is unreachable.
+      } catch (error) {
+        // Keep polling while unavailable, but retain diagnostics for debugging.
+        console.warn("Maintenance status check failed", error);
       }
     }, 30_000);
     return () => {
@@ -32,7 +33,7 @@ function MaintenanceOverlay() {
 
   return (
     <div className="flex flex-1 items-center justify-center p-5">
-      <Empty className="w-full max-w-xl overflow-hidden text-center">
+      <Empty className="w-full max-w-2xl overflow-hidden text-center">
         <div className="w-full" />
 
         <EmptyHeader className="flex flex-col items-center">

--- a/src/services/base-api.service.ts
+++ b/src/services/base-api.service.ts
@@ -119,9 +119,14 @@ export class BaseApiService {
    * Intercept 503 responses and halt execution
    */
   private async checkMaintenance(response: Response): Promise<void> {
-    if (response.status === 503 && typeof window !== "undefined") {
-      window.dispatchEvent(new Event("backend-maintenance"));
-      return await new Promise<never>(() => {
+    const runtimeWindow = (globalThis as { window?: Window | null }).window;
+    if (
+      response.status === 503 &&
+      runtimeWindow !== undefined &&
+      runtimeWindow !== null
+    ) {
+      runtimeWindow.dispatchEvent(new Event("backend-maintenance"));
+      await new Promise<never>(() => {
         /* empty */
       });
     }


### PR DESCRIPTION
Follow-up to #314 after rebasing the maintenance fixes onto the current `dev` branch.

## Changes
- trigger maintenance mode only for browser-side HTTP 503 responses, including the post-refresh retry path;
- keep SSR and ordinary network failures on the normal error path;
- reload only after a confirmed healthy polling response and retain polling failures as diagnostics;
- add focused regression coverage for these boundaries.

## Validation
- `pnpm test --run src/__tests__/maintenance.spec.tsx` — 11 passed
- targeted ESLint — passed
- `pnpm format:check` — passed
- `pnpm typecheck` — passed after the repository build generated Next types
- `next build --webpack` with non-secret local validation placeholders — passed
- `git diff --check origin/dev...HEAD` — passed