### PR TITLE
feat(profile): upload and reset persisted profile photos

### DIFF
--- a/src/__tests__/profile-photo-auth.spec.tsx
+++ b/src/__tests__/profile-photo-auth.spec.tsx
@@ -1,0 +1,38 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+
+import { useSyncAuth } from "@/hooks/use-sync-auth";
+import type { JWTPayload } from "@/lib/auth/types";
+
+const mocks = vi.hoisted(() => ({ read: vi.fn(), decode: vi.fn() }));
+vi.mock("@/lib/cookies", () => ({
+  AUTH_COOKIE_NAMES: {
+    ACCESS_TOKEN: "access_token",
+    REFRESH_TOKEN: "refresh_token",
+  },
+  getCookie: mocks.read,
+}));
+vi.mock("@/lib/auth/jwt-utils", () => ({ decodeAccessToken: mocks.decode }));
+vi.mock("@/services", () => ({
+  getUserService: () => ({ refreshToken: vi.fn() }),
+}));
+
+it("updates the avatar after token refresh without a Cookie Store change or window focus", async () => {
+  const original = { user_id: "photo-user", photo: "old-photo" } as JWTPayload;
+  const updated = { ...original, photo: "new-photo" };
+  mocks.read.mockReturnValue("token");
+  mocks.decode.mockReturnValue(original);
+  const { result } = renderHook(() => useSyncAuth(original));
+  await waitFor(() => {
+    expect(result.current.user?.photo).toBe("old-photo");
+  });
+
+  mocks.decode.mockReturnValue(updated);
+  act(() => {
+    window.dispatchEvent(new Event("auth-token-refreshed"));
+  });
+
+  await waitFor(() => {
+    expect(result.current.user?.photo).toBe("new-photo");
+  });
+});

--- a/src/__tests__/profile-photo.spec.tsx
+++ b/src/__tests__/profile-photo.spec.tsx
@@ -46,7 +46,9 @@ const profile: UserData = {
   account_level: "basic",
 };
 
-function setup(userData = profile) {
+const goldProfile: UserData = { ...profile, account_level: "gold" };
+
+function setup(userData: UserData = goldProfile) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -71,6 +73,84 @@ afterEach(() => {
 });
 
 describe("profile photo editor", () => {
+  it.each(["basic", "silver"] as const)(
+    "lets %s users pick a predefined avatar but not upload a file",
+    async (accountLevel) => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: vi
+          .fn()
+          .mockResolvedValue(new Blob(["preset-image"], { type: "image/png" })),
+      });
+      vi.stubGlobal("fetch", fetch);
+      mocks.upload.mockResolvedValue({ ...profile, has_custom_photo: true });
+      const { onClose } = setup({ ...profile, account_level: accountLevel });
+      expect(screen.queryByLabelText("Wybierz plik")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("button", { name: /^Awatar / })).toHaveLength(
+        8,
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Awatar 2" }));
+      expect(screen.getByRole("button", { name: "Awatar 2" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Zapisz zdjęcie" }),
+      );
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalledOnce();
+      });
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.dicebear.com/9.x/adventurer/png?seed=Anna+Nowak+2",
+      );
+      const uploaded = mocks.upload.mock.calls[0][0] as File;
+      expect(uploaded).toBeInstanceOf(File);
+      expect(uploaded.name).toBe("avatar.png");
+      expect(uploaded.type).toBe("image/png");
+      expect(uploaded.size).toBe(12);
+    },
+  );
+
+  it("keeps a failed preset selection available for retry without uploading a URL", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const { onClose } = setup(profile);
+    await userEvent.click(screen.getByRole("button", { name: "Awatar 1" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Zapisz zdjęcie" }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Nie udało się zapisać",
+    );
+    expect(mocks.upload).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Awatar 1" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Zapisz zdjęcie" }),
+    ).toBeEnabled();
+  });
+
+  it("lets Gold users switch between a preset and the same personal file", async () => {
+    setup();
+    const user = userEvent.setup();
+    const file = new File(["photo"], "photo.png", { type: "image/png" });
+    await user.upload(screen.getByLabelText("Wybierz plik"), file);
+    await user.click(screen.getByRole("button", { name: "Awatar 1" }));
+    expect(mocks.revokePreview).toHaveBeenCalledWith("blob:photo-preview");
+    await user.upload(screen.getByLabelText("Wybierz plik"), file);
+    expect(screen.getByRole("button", { name: "Awatar 1" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    mocks.upload.mockResolvedValue(profile);
+    await user.click(screen.getByRole("button", { name: "Zapisz zdjęcie" }));
+    await waitFor(() => {
+      expect(mocks.upload).toHaveBeenCalledWith(file);
+    });
+  });
+
   it("uploads a file, updates the profile cache, refreshes the avatar and releases the preview", async () => {
     const updated = {
       ...profile,

--- a/src/__tests__/profile-photo.spec.tsx
+++ b/src/__tests__/profile-photo.spec.tsx
@@ -1,0 +1,168 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProfilePhotoDialog } from "@/components/profile/profile-photo-dialog";
+import { userProfileQueryKey } from "@/hooks/use-user-profile";
+import { UserService } from "@/services/user.service";
+import type { UserData } from "@/types/user";
+
+const mocks = vi.hoisted(() => ({
+  upload: vi.fn(),
+  remove: vi.fn(),
+  refreshToken: vi.fn(),
+  refresh: vi.fn(),
+  revokePreview: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}));
+vi.mock("@/services", () => ({
+  getUserService: () => ({
+    uploadProfilePhoto: mocks.upload,
+    deleteProfilePhoto: mocks.remove,
+    refreshToken: mocks.refreshToken,
+  }),
+}));
+
+const profile: UserData = {
+  id: "user-1",
+  full_name: "Anna Nowak",
+  photo: null,
+  student_number: "123",
+  email: "anna@example.com",
+  has_custom_photo: false,
+  is_superuser: false,
+  is_staff: false,
+  hide_profile: false,
+  account_type: "email",
+  account_level: "basic",
+};
+
+function setup(userData = profile) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const onClose = vi.fn();
+  const view = render(
+    <QueryClientProvider client={client}>
+      <ProfilePhotoDialog userData={userData} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+  return { client, onClose, ...view };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.refreshToken.mockResolvedValue(true);
+  URL.createObjectURL = vi.fn(() => "blob:photo-preview");
+  URL.revokeObjectURL = mocks.revokePreview;
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("profile photo editor", () => {
+  it("uploads a file, updates the profile cache, refreshes the avatar and releases the preview", async () => {
+    const updated = {
+      ...profile,
+      photo: "https://test.local/media/photo.avif",
+      has_custom_photo: true,
+    };
+    mocks.upload.mockResolvedValue(updated);
+    const { client, onClose, unmount } = setup();
+    const user = userEvent.setup();
+    const file = new File(["photo"], "photo.png", { type: "image/png" });
+    await user.upload(screen.getByLabelText("Wybierz plik"), file);
+    await user.click(screen.getByRole("button", { name: "Zapisz zdjęcie" }));
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+    expect(mocks.upload).toHaveBeenCalledWith(file);
+    expect(client.getQueryData(userProfileQueryKey)).toEqual(updated);
+    expect(mocks.refreshToken).toHaveBeenCalledOnce();
+    expect(mocks.refresh).toHaveBeenCalledOnce();
+    unmount();
+    expect(mocks.revokePreview).toHaveBeenCalledWith("blob:photo-preview");
+  });
+
+  it("restores the account photo and updates has_custom_photo", async () => {
+    mocks.remove.mockResolvedValue(profile);
+    const { client, onClose } = setup({ ...profile, has_custom_photo: true });
+    await userEvent.click(
+      screen.getByRole("button", { name: "Przywróć domyślne zdjęcie" }),
+    );
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+    expect(mocks.remove).toHaveBeenCalledOnce();
+    expect(client.getQueryData(userProfileQueryKey)).toEqual(profile);
+  });
+
+  it("keeps the selected file and dialog open when the upload fails", async () => {
+    mocks.upload.mockRejectedValue(new Error("offline"));
+    const { onClose } = setup();
+    await userEvent.upload(
+      screen.getByLabelText("Wybierz plik"),
+      new File(["photo"], "photo.png", { type: "image/png" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Zapisz zdjęcie" }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Nie udało się zapisać",
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Zapisz zdjęcie" }),
+    ).toBeEnabled();
+    expect(mocks.refreshToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects SVG and oversized files before sending a request", () => {
+    setup();
+    const input = screen.getByLabelText("Wybierz plik");
+    for (const file of [
+      new File(["svg"], "avatar.svg", { type: "image/svg+xml" }),
+      new File([new Uint8Array(10 * 1024 * 1024 + 1)], "large.png", {
+        type: "image/png",
+      }),
+    ]) {
+      fireEvent.change(input, { target: { files: [file] } });
+      expect(screen.getByRole("alert")).toHaveTextContent("do 10 MB");
+      expect(
+        screen.getByRole("button", { name: "Zapisz zdjęcie" }),
+      ).toBeDisabled();
+    }
+    expect(mocks.upload).not.toHaveBeenCalled();
+  });
+});
+
+it("sends multipart photo content without forcing a JSON Content-Type and uses DELETE to reset", async () => {
+  const fetch = vi
+    .fn()
+    .mockResolvedValue(Response.json(profile, { status: 200 }));
+  vi.stubGlobal("fetch", fetch);
+  const service = new UserService("http://test.local/api/");
+  const file = new File(["photo"], "photo.png", { type: "image/png" });
+  await service.uploadProfilePhoto(file);
+  const [url, options] = fetch.mock.calls[0] as [string, RequestInit];
+  expect(url).toBe("http://test.local/api/user/photo/");
+  expect(options.method).toBe("POST");
+  expect((options.body as FormData).get("photo")).toBe(file);
+  expect(new Headers(options.headers).has("Content-Type")).toBe(false);
+  fetch.mockResolvedValue(Response.json(profile, { status: 200 }));
+  await service.deleteProfilePhoto();
+  expect(fetch).toHaveBeenLastCalledWith(
+    url,
+    expect.objectContaining({ method: "DELETE" }),
+  );
+});

--- a/src/app-context-provider.tsx
+++ b/src/app-context-provider.tsx
@@ -24,7 +24,7 @@ export function AppContextProvider({
   useGuestQuizMigration(user);
 
   const checkPermission = (action: PermissionAction) =>
-    hasPermission(user?.account_type, action);
+    hasPermission(user?.account_type, action, user?.account_level);
 
   const context: AppContextType = {
     isAuthenticated,

--- a/src/app/profile/client.tsx
+++ b/src/app/profile/client.tsx
@@ -56,7 +56,7 @@ function getUserProfilePlaceholder(
 
   return {
     ...user,
-    photo: user.photo ?? "",
+    photo: user.photo ?? null,
     has_custom_photo: false,
     hide_profile: false,
     id: user.user_id,

--- a/src/app/profile/client.tsx
+++ b/src/app/profile/client.tsx
@@ -57,8 +57,7 @@ function getUserProfilePlaceholder(
   return {
     ...user,
     photo: user.photo ?? "",
-    photo_url: user.photo ?? "",
-    overriden_photo_url: user.photo,
+    has_custom_photo: false,
     hide_profile: false,
     id: user.user_id,
   };

--- a/src/components/profile/profile-details.tsx
+++ b/src/components/profile/profile-details.tsx
@@ -1,29 +1,21 @@
 import { IdCardLanyardIcon, PencilIcon } from "lucide-react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { AccountLevelBadge } from "@/components/account-level-badge";
 import { AccountTypeBadge } from "@/components/account-type-badge";
+import { ProfilePhotoDialog } from "@/components/profile/profile-photo-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { useUpdateUserProfile } from "@/hooks/use-user-profile";
 import { getAccountLevelProfileAvatarClassName } from "@/lib/account-level";
 import { cn, getInitials } from "@/lib/utils";
-import { getUserService } from "@/services";
 import { ACCOUNT_LEVEL, ACCOUNT_TYPE } from "@/types/user";
 import type { UserData } from "@/types/user";
 
@@ -36,42 +28,6 @@ export function ProfileDetails({ userData, loading }: ProfileDetailsProps) {
   const router = useRouter();
   const updateUserProfile = useUpdateUserProfile();
   const [showDialog, setShowDialog] = useState(false);
-  const [selectedPhoto, setSelectedPhoto] = useState(userData?.photo ?? "");
-
-  useEffect(() => {
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
-    setSelectedPhoto(userData?.photo ?? "");
-  }, [userData?.photo]);
-
-  const handleOpenDialog = () => {
-    setShowDialog(true);
-  };
-  const handleCloseDialog = () => {
-    setSelectedPhoto(userData?.photo ?? "");
-    setShowDialog(false);
-  };
-
-  const handleSavePhoto = () => {
-    handleCloseDialog();
-    updateUserProfile.mutate(
-      {
-        overriden_photo_url:
-          selectedPhoto === userData?.photo_url ? null : selectedPhoto,
-      },
-      {
-        onSuccess: async () => {
-          // Refresh token to get updated user data (avatar) in the token payload
-          await getUserService().refreshToken();
-          router.refresh();
-        },
-        onError: (error: unknown) => {
-          console.error("Error saving photo:", error);
-          toast.error("Wystąpił błąd podczas zapisywania zdjęcia profilowego.");
-        },
-      },
-    );
-  };
-
   const handleHideProfile = (hide: boolean) => {
     updateUserProfile.mutate(
       { hide_profile: hide },
@@ -83,34 +39,6 @@ export function ProfileDetails({ userData, loading }: ProfileDetailsProps) {
       },
     );
   };
-
-  const avatarOptions = [
-    userData?.photo_url ?? "",
-    encodeURI(
-      `https://api.dicebear.com/9.x/adventurer/svg?seed=${userData?.full_name ?? "default"}`,
-    ),
-    encodeURI(
-      `https://api.dicebear.com/9.x/adventurer/svg?seed=${userData?.full_name ?? "default"} 2`,
-    ),
-    encodeURI(
-      `https://api.dicebear.com/9.x/adventurer/svg?seed=${userData?.full_name ?? "default"} 3`,
-    ),
-    encodeURI(
-      `https://api.dicebear.com/9.x/dylan/svg?seed=${userData?.full_name ?? "default"}`,
-    ),
-    encodeURI(
-      `https://api.dicebear.com/9.x/micah/svg?seed=${userData?.full_name ?? "default"}`,
-    ),
-    encodeURI(
-      `https://api.dicebear.com/9.x/micah/svg?seed=${userData?.full_name ?? "default"} 2`,
-    ),
-    encodeURI(
-      `https://api.dicebear.com/9.x/shapes/svg?seed=${userData?.full_name ?? "default"}`,
-    ),
-    encodeURI(
-      `https://api.dicebear.com/9.x/initials/svg?seed=${userData?.full_name ?? "default"}`,
-    ),
-  ];
 
   if (userData?.account_type === ACCOUNT_TYPE.GUEST) {
     return (
@@ -195,7 +123,7 @@ export function ProfileDetails({ userData, loading }: ProfileDetailsProps) {
                 )}
               >
                 <AvatarImage
-                  src={userData?.photo}
+                  src={userData?.photo ?? undefined}
                   alt={`Zdjęcie profilowe użytkownika ${userData?.full_name ?? ""}`}
                 />
                 <AvatarFallback className="text-3xl" delay={600}>
@@ -203,7 +131,10 @@ export function ProfileDetails({ userData, loading }: ProfileDetailsProps) {
                 </AvatarFallback>
               </Avatar>
               <button
-                onClick={handleOpenDialog}
+                aria-label="Zmień zdjęcie profilowe"
+                onClick={() => {
+                  setShowDialog(true);
+                }}
                 className="bg-background hover:bg-accent absolute top-0 -right-2 inline-flex size-8 items-center justify-center rounded-full border shadow transition"
               >
                 <PencilIcon className="size-4" />
@@ -273,80 +204,14 @@ export function ProfileDetails({ userData, loading }: ProfileDetailsProps) {
           </CardContent>
         )}
       </Card>
-      <Dialog
-        open={showDialog}
-        onOpenChange={(open) => {
-          if (open) {
-            setShowDialog(true);
-          } else {
-            handleCloseDialog();
-          }
-        }}
-      >
-        <DialogContent className="max-w-2xl" aria-describedby={undefined}>
-          <DialogHeader>
-            <DialogTitle>Wybierz zdjęcie profilowe</DialogTitle>
-          </DialogHeader>
-          <div className="flex flex-wrap justify-center gap-4">
-            {avatarOptions.map((url, index) => (
-              <Button
-                key={`avatar-select-${index.toString()}`}
-                variant="ghost"
-                className={cn(
-                  "size-20 rounded-full p-0 ring-2 transition-all hover:shadow-xl",
-                  selectedPhoto === url
-                    ? "ring-primary shadow-lg"
-                    : "ring-transparent",
-                )}
-                onClick={() => {
-                  setSelectedPhoto(url);
-                }}
-              >
-                <Image
-                  key={`avatar-option-${index.toString()}`}
-                  src={url}
-                  alt={`Avatar ${index.toString()}`}
-                  className="size-20 rounded-full object-cover"
-                  unoptimized
-                  width={80}
-                  height={80}
-                />
-              </Button>
-            ))}
-            {!avatarOptions.includes(selectedPhoto) && selectedPhoto ? (
-              <Button
-                variant="ghost"
-                className="ring-primary size-20 rounded-full p-0 shadow-lg ring-2 transition-all hover:shadow-xl"
-                onClick={() =>
-                  toast(
-                    "To zdjęcie nie jest już dostępne. Po zmianie na inne nie będzie możliwości powrotu.",
-                  )
-                }
-              >
-                <Image
-                  src={selectedPhoto}
-                  alt="Wybrane zdjęcie"
-                  className="size-20 rounded-full object-cover"
-                  unoptimized
-                  width={96}
-                  height={96}
-                />
-              </Button>
-            ) : null}
-          </div>
-          <DialogFooter className="flex justify-end gap-2">
-            <Button variant="outline" onClick={handleCloseDialog}>
-              Anuluj
-            </Button>
-            <Button
-              onClick={handleSavePhoto}
-              disabled={updateUserProfile.isPending}
-            >
-              Zapisz
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {showDialog && userData !== null ? (
+        <ProfilePhotoDialog
+          userData={userData}
+          onClose={() => {
+            setShowDialog(false);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/profile/profile-photo-dialog.tsx
+++ b/src/components/profile/profile-photo-dialog.tsx
@@ -1,0 +1,185 @@
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useUpdateProfilePhoto } from "@/hooks/use-user-profile";
+import { getInitials } from "@/lib/utils";
+import { getUserService } from "@/services";
+import type { UserData } from "@/types/user";
+
+const ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+];
+const MAX_PHOTO_SIZE = 10 * 1024 * 1024;
+
+export function ProfilePhotoDialog({
+  userData,
+  onClose,
+}: {
+  userData: UserData;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const mutation = useUpdateProfilePhoto();
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string>();
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (file === null) {
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreview(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
+
+  const save = async (photo: File | null) => {
+    if (saving) {
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await mutation.mutateAsync(photo);
+    } catch {
+      setError(
+        "Nie udało się zapisać zdjęcia. Sprawdź plik i spróbuj ponownie.",
+      );
+      setSaving(false);
+      return;
+    }
+    // The photo is already saved even if refreshing the session fails.
+    try {
+      const refreshed = await getUserService().refreshToken();
+      if (!refreshed) {
+        toast.warning(
+          "Zdjęcie zapisano. Awatar w menu odświeży się po ponownym zalogowaniu.",
+        );
+      }
+    } catch {
+      toast.warning(
+        "Zdjęcie zapisano. Awatar w menu odświeży się po ponownym zalogowaniu.",
+      );
+    }
+    router.refresh();
+    toast.success(
+      photo === null
+        ? "Przywrócono domyślne zdjęcie."
+        : "Zapisano zdjęcie profilowe.",
+    );
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !saving) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md" showCloseButton={!saving}>
+        <DialogHeader>
+          <DialogTitle>Zmień zdjęcie profilowe</DialogTitle>
+          <DialogDescription>
+            Wgraj własne zdjęcie lub przywróć zdjęcie przypisane do konta.
+          </DialogDescription>
+        </DialogHeader>
+        <Avatar className="mx-auto size-24">
+          <AvatarImage
+            src={file === null ? (userData.photo ?? undefined) : preview}
+            alt="Podgląd zdjęcia profilowego"
+          />
+          <AvatarFallback>{getInitials(userData.full_name)}</AvatarFallback>
+        </Avatar>
+        <div className="space-y-2">
+          <Label htmlFor="profile-photo">Wybierz plik</Label>
+          <Input
+            id="profile-photo"
+            type="file"
+            accept={ACCEPTED_TYPES.join(",")}
+            disabled={saving}
+            aria-describedby="profile-photo-hint profile-photo-error"
+            aria-invalid={error !== null}
+            onChange={(event) => {
+              const selected = event.target.files?.[0];
+              setError(null);
+              if (selected === undefined) {
+                return;
+              }
+              if (
+                !ACCEPTED_TYPES.includes(selected.type) ||
+                selected.size > MAX_PHOTO_SIZE
+              ) {
+                setFile(null);
+                event.target.value = "";
+                setError(
+                  "Wybierz plik JPEG, PNG, GIF, WebP lub AVIF o rozmiarze do 10 MB.",
+                );
+                return;
+              }
+              setFile(selected);
+            }}
+          />
+          <p id="profile-photo-hint" className="text-muted-foreground text-sm">
+            JPEG, PNG, GIF, WebP lub AVIF. Maksymalnie 10 MB.
+          </p>
+          {error === null ? null : (
+            <p
+              id="profile-photo-error"
+              role="alert"
+              className="text-destructive text-sm"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+        {userData.has_custom_photo ? (
+          <Button
+            variant="outline"
+            disabled={saving}
+            onClick={() => {
+              void save(null);
+            }}
+          >
+            Przywróć domyślne zdjęcie
+          </Button>
+        ) : null}
+        <DialogFooter>
+          <Button variant="outline" disabled={saving} onClick={onClose}>
+            Anuluj
+          </Button>
+          <Button
+            disabled={file === null || saving}
+            onClick={() => {
+              void save(file);
+            }}
+          >
+            {saving ? "Zapisywanie…" : "Zapisz zdjęcie"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/profile/profile-photo-dialog.tsx
+++ b/src/components/profile/profile-photo-dialog.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -15,7 +15,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useUpdateProfilePhoto } from "@/hooks/use-user-profile";
-import { getInitials } from "@/lib/utils";
+import { PermissionAction, hasPermission } from "@/lib/auth/permissions";
+import {
+  fetchProfileAvatar,
+  getProfileAvatarOptions,
+} from "@/lib/profile-avatars";
+import { cn, getInitials } from "@/lib/utils";
 import { getUserService } from "@/services";
 import type { UserData } from "@/types/user";
 
@@ -37,10 +42,18 @@ export function ProfilePhotoDialog({
 }) {
   const router = useRouter();
   const mutation = useUpdateProfilePhoto();
+  const fileInput = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
+  const [selectedAvatar, setSelectedAvatar] = useState<string | null>(null);
   const [preview, setPreview] = useState<string>();
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const canUpload = hasPermission(
+    userData.account_type,
+    PermissionAction.UPLOAD_PROFILE_PHOTO,
+    userData.account_level,
+  );
+  const avatarOptions = getProfileAvatarOptions(userData.full_name);
 
   useEffect(() => {
     if (file === null) {
@@ -53,17 +66,21 @@ export function ProfilePhotoDialog({
     };
   }, [file]);
 
-  const save = async (photo: File | null) => {
+  const save = async (selection: File | string | null) => {
     if (saving) {
       return;
     }
     setSaving(true);
     setError(null);
     try {
+      const photo =
+        typeof selection === "string"
+          ? await fetchProfileAvatar(selection)
+          : selection;
       await mutation.mutateAsync(photo);
     } catch {
       setError(
-        "Nie udało się zapisać zdjęcia. Sprawdź plik i spróbuj ponownie.",
+        "Nie udało się zapisać zdjęcia. Sprawdź połączenie lub wybierz inne zdjęcie i spróbuj ponownie.",
       );
       setSaving(false);
       return;
@@ -83,7 +100,7 @@ export function ProfilePhotoDialog({
     }
     router.refresh();
     toast.success(
-      photo === null
+      selection === null
         ? "Przywrócono domyślne zdjęcie."
         : "Zapisano zdjęcie profilowe.",
     );
@@ -99,62 +116,116 @@ export function ProfilePhotoDialog({
         }
       }}
     >
-      <DialogContent className="sm:max-w-md" showCloseButton={!saving}>
+      <DialogContent
+        className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-md"
+        showCloseButton={!saving}
+      >
         <DialogHeader>
           <DialogTitle>Zmień zdjęcie profilowe</DialogTitle>
           <DialogDescription>
-            Wgraj własne zdjęcie lub przywróć zdjęcie przypisane do konta.
+            {canUpload
+              ? "Wybierz gotowy awatar, wgraj własne zdjęcie lub przywróć zdjęcie przypisane do konta."
+              : "Wybierz gotowy awatar lub przywróć zdjęcie przypisane do konta."}
           </DialogDescription>
         </DialogHeader>
         <Avatar className="mx-auto size-24">
           <AvatarImage
-            src={file === null ? (userData.photo ?? undefined) : preview}
+            src={
+              selectedAvatar ??
+              (file === null ? (userData.photo ?? undefined) : preview)
+            }
             alt="Podgląd zdjęcia profilowego"
           />
           <AvatarFallback>{getInitials(userData.full_name)}</AvatarFallback>
         </Avatar>
-        <div className="space-y-2">
-          <Label htmlFor="profile-photo">Wybierz plik</Label>
-          <Input
-            id="profile-photo"
-            type="file"
-            accept={ACCEPTED_TYPES.join(",")}
-            disabled={saving}
-            aria-describedby="profile-photo-hint profile-photo-error"
-            aria-invalid={error !== null}
-            onChange={(event) => {
-              const selected = event.target.files?.[0];
-              setError(null);
-              if (selected === undefined) {
-                return;
-              }
-              if (
-                !ACCEPTED_TYPES.includes(selected.type) ||
-                selected.size > MAX_PHOTO_SIZE
-              ) {
+        <div
+          role="group"
+          aria-label="Gotowe awatary"
+          className="grid grid-cols-4 justify-items-center gap-3"
+        >
+          {avatarOptions.map((url, index) => (
+            <Button
+              key={url}
+              variant="ghost"
+              className={cn(
+                "size-12 rounded-full p-0 sm:size-16",
+                selectedAvatar === url && "ring-primary ring-2",
+              )}
+              aria-label={`Awatar ${String(index + 1)}`}
+              aria-pressed={selectedAvatar === url}
+              disabled={saving}
+              onClick={() => {
+                setSelectedAvatar(url);
                 setFile(null);
-                event.target.value = "";
-                setError(
-                  "Wybierz plik JPEG, PNG, GIF, WebP lub AVIF o rozmiarze do 10 MB.",
-                );
-                return;
-              }
-              setFile(selected);
-            }}
-          />
-          <p id="profile-photo-hint" className="text-muted-foreground text-sm">
-            JPEG, PNG, GIF, WebP lub AVIF. Maksymalnie 10 MB.
-          </p>
-          {error === null ? null : (
-            <p
-              id="profile-photo-error"
-              role="alert"
-              className="text-destructive text-sm"
+                if (fileInput.current !== null) {
+                  fileInput.current.value = "";
+                }
+                setError(null);
+              }}
             >
-              {error}
-            </p>
-          )}
+              <Avatar className="size-12 sm:size-16">
+                <AvatarImage src={url} alt="" />
+                <AvatarFallback>
+                  {getInitials(userData.full_name)}
+                </AvatarFallback>
+              </Avatar>
+            </Button>
+          ))}
         </div>
+        {canUpload ? (
+          <div className="space-y-2">
+            <Label htmlFor="profile-photo">Wybierz plik</Label>
+            <Input
+              ref={fileInput}
+              id="profile-photo"
+              type="file"
+              accept={ACCEPTED_TYPES.join(",")}
+              disabled={saving}
+              aria-describedby="profile-photo-hint profile-photo-error"
+              aria-invalid={error !== null}
+              onChange={(event) => {
+                const selected = event.target.files?.[0];
+                setError(null);
+                if (selected === undefined) {
+                  return;
+                }
+                if (
+                  !ACCEPTED_TYPES.includes(selected.type) ||
+                  selected.size > MAX_PHOTO_SIZE
+                ) {
+                  setFile(null);
+                  setSelectedAvatar(null);
+                  event.target.value = "";
+                  setError(
+                    "Wybierz plik JPEG, PNG, GIF, WebP lub AVIF o rozmiarze do 10 MB.",
+                  );
+                  return;
+                }
+                setFile(selected);
+                setSelectedAvatar(null);
+              }}
+            />
+            <p
+              id="profile-photo-hint"
+              className="text-muted-foreground text-sm"
+            >
+              JPEG, PNG, GIF, WebP lub AVIF. Maksymalnie 10 MB.
+            </p>
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            Własne zdjęcia możesz wgrywać z kontem Gold.
+          </p>
+        )}
+        {error === null ? null : (
+          <p
+            id="profile-photo-error"
+            role="alert"
+            className="text-destructive text-sm"
+          >
+            {error}
+          </p>
+        )}
         {userData.has_custom_photo ? (
           <Button
             variant="outline"
@@ -171,9 +242,9 @@ export function ProfilePhotoDialog({
             Anuluj
           </Button>
           <Button
-            disabled={file === null || saving}
+            disabled={(file === null && selectedAvatar === null) || saving}
             onClick={() => {
-              void save(file);
+              void save(selectedAvatar ?? file);
             }}
           >
             {saving ? "Zapisywanie…" : "Zapisz zdjęcie"}

--- a/src/hooks/use-sync-auth.ts
+++ b/src/hooks/use-sync-auth.ts
@@ -117,6 +117,7 @@ export function useSyncAuth(initialUser: JWTPayload | null) {
       cookieStore.addEventListener("change", handleCookieStoreChange);
     }
     window.addEventListener("focus", handleFocus);
+    window.addEventListener("auth-token-refreshed", handleFocus);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
@@ -124,6 +125,7 @@ export function useSyncAuth(initialUser: JWTPayload | null) {
         cookieStore.removeEventListener("change", handleCookieStoreChange);
       }
       window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("auth-token-refreshed", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [syncAuthFromCookies]);

--- a/src/hooks/use-user-profile.ts
+++ b/src/hooks/use-user-profile.ts
@@ -5,6 +5,20 @@ import type { UserData } from "@/types/user";
 
 export const userProfileQueryKey = ["user-profile"] as const;
 
+export function useUpdateProfilePhoto() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (file: File | null) =>
+      file === null
+        ? getUserService().deleteProfilePhoto()
+        : getUserService().uploadProfilePhoto(file),
+    onSuccess: (updatedUserData) => {
+      queryClient.setQueryData<UserData>(userProfileQueryKey, updatedUserData);
+    },
+  });
+}
+
 export function useUserProfile({
   placeholderData,
 }: { placeholderData?: UserData } = {}) {

--- a/src/lib/auth/permissions.spec.ts
+++ b/src/lib/auth/permissions.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { ACCOUNT_LEVELS, ACCOUNT_TYPES } from "@/types/user";
+
+import { PermissionAction, hasPermission } from "./permissions";
+
+describe("profile photo upload permission", () => {
+  for (const accountType of ACCOUNT_TYPES) {
+    it.each(ACCOUNT_LEVELS)(
+      `${accountType} / %s follows the Gold-only permission`,
+      (accountLevel) => {
+        expect(
+          hasPermission(
+            accountType,
+            PermissionAction.UPLOAD_PROFILE_PHOTO,
+            accountLevel,
+          ),
+        ).toBe(accountType !== "guest" && accountLevel === "gold");
+      },
+    );
+  }
+
+  it("does not grant uploads to missing accounts or unknown levels", () => {
+    expect(
+      hasPermission(undefined, PermissionAction.UPLOAD_PROFILE_PHOTO, "gold"),
+    ).toBe(false);
+    expect(hasPermission("email", PermissionAction.UPLOAD_PROFILE_PHOTO)).toBe(
+      false,
+    );
+  });
+
+  it("preserves permissions that do not depend on account level", () => {
+    expect(hasPermission("email", PermissionAction.NOTIFICATION_SETTINGS)).toBe(
+      true,
+    );
+    expect(
+      hasPermission("guest", PermissionAction.NOTIFICATION_SETTINGS, "gold"),
+    ).toBe(false);
+  });
+});

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -1,5 +1,5 @@
-import { ACCOUNT_TYPE } from "@/types/user";
-import type { AccountType } from "@/types/user";
+import { ACCOUNT_LEVEL, ACCOUNT_TYPE } from "@/types/user";
+import type { AccountLevel, AccountType } from "@/types/user";
 
 export enum PermissionAction {
   // Searching and browsing public quizzes
@@ -24,6 +24,8 @@ export enum PermissionAction {
   VIEW_QUIZ_STATS = "view_quiz_stats",
   // Viewing Testownik Wrapped summaries
   VIEW_WRAPPED = "view_wrapped",
+  // Uploading a personal profile photo (predefined avatars remain available to all accounts)
+  UPLOAD_PROFILE_PHOTO = "upload_profile_photo",
 }
 
 export const PERMISSIONS_BY_ROLE: Record<
@@ -36,6 +38,7 @@ export const PERMISSIONS_BY_ROLE: Record<
     PermissionAction.SEARCH_IN_QUIZ,
   ],
   [ACCOUNT_TYPE.EMAIL]: [
+    PermissionAction.UPLOAD_PROFILE_PHOTO,
     PermissionAction.VIEW_SHARED_QUIZZES,
     PermissionAction.SHARE_QUIZZES,
     PermissionAction.REPORT_QUIZ_ISSUES,
@@ -47,6 +50,7 @@ export const PERMISSIONS_BY_ROLE: Record<
     PermissionAction.VIEW_WRAPPED,
   ],
   [ACCOUNT_TYPE.STUDENT]: [
+    PermissionAction.UPLOAD_PROFILE_PHOTO,
     PermissionAction.BROWSE_PUBLIC_QUIZZES,
     PermissionAction.VIEW_SHARED_QUIZZES,
     PermissionAction.SHARE_QUIZZES,
@@ -60,6 +64,7 @@ export const PERMISSIONS_BY_ROLE: Record<
     PermissionAction.VIEW_WRAPPED,
   ],
   [ACCOUNT_TYPE.LECTURER]: [
+    PermissionAction.UPLOAD_PROFILE_PHOTO,
     PermissionAction.VIEW_SHARED_QUIZZES,
     PermissionAction.SHARE_QUIZZES,
     PermissionAction.REPORT_QUIZ_ISSUES,
@@ -72,9 +77,21 @@ export const PERMISSIONS_BY_ROLE: Record<
   ],
 };
 
+export const ACCOUNT_LEVEL_REQUIREMENTS: Partial<
+  Record<PermissionAction, readonly AccountLevel[]>
+> = {
+  [PermissionAction.UPLOAD_PROFILE_PHOTO]: [ACCOUNT_LEVEL.GOLD],
+};
+
 export function hasPermission(
   accountType: AccountType | undefined,
   action: PermissionAction,
+  accountLevel?: AccountLevel,
 ): boolean {
-  return PERMISSIONS_BY_ROLE[accountType ?? "unauthenticated"].includes(action);
+  const allowedLevels = ACCOUNT_LEVEL_REQUIREMENTS[action];
+  return (
+    PERMISSIONS_BY_ROLE[accountType ?? "unauthenticated"].includes(action) &&
+    (allowedLevels === undefined ||
+      (accountLevel !== undefined && allowedLevels.includes(accountLevel)))
+  );
 }

--- a/src/lib/profile-avatars.ts
+++ b/src/lib/profile-avatars.ts
@@ -1,0 +1,30 @@
+// Preserve the original profile picker styles and seed variants, using raster
+// endpoints so the chosen image can be uploaded through the shared photo API.
+const AVATAR_STYLES = [
+  ["adventurer", ""],
+  ["adventurer", " 2"],
+  ["adventurer", " 3"],
+  ["dylan", ""],
+  ["micah", ""],
+  ["micah", " 2"],
+  ["shapes", ""],
+  ["initials", ""],
+] as const;
+
+export function getProfileAvatarOptions(fullName: string) {
+  return AVATAR_STYLES.map(([style, suffix]) => {
+    const parameters = new URLSearchParams({
+      seed: `${fullName || "default"}${suffix}`,
+    });
+    return `https://api.dicebear.com/9.x/${style}/png?${parameters.toString()}`;
+  });
+}
+
+export async function fetchProfileAvatar(url: string): Promise<File> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error("Could not download the selected avatar");
+  }
+  const image = await response.blob();
+  return new File([image], "avatar.png", { type: "image/png" });
+}

--- a/src/services/base-api.service.ts
+++ b/src/services/base-api.service.ts
@@ -269,6 +269,9 @@ export class BaseApiService {
           }
           return false;
         }
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new Event("auth-token-refreshed"));
+        }
         return true;
       } catch {
         return false;

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -162,6 +162,20 @@ export class UserService extends BaseApiService {
     return response.data;
   }
 
+  async uploadProfilePhoto(file: File): Promise<UserData> {
+    const response = await this.uploadFile<UserData>(
+      "user/photo/",
+      file,
+      "photo",
+    );
+    return response.data;
+  }
+
+  async deleteProfilePhoto(): Promise<UserData> {
+    const response = await this.delete<UserData>("user/photo/");
+    return response.data;
+  }
+
   /**
    * Update user profile
    */

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -37,10 +37,10 @@ export interface User {
   account_level?: AccountLevel;
 }
 
-export interface UserData extends User {
+export interface UserData extends Omit<User, "photo"> {
+  photo: string | null;
   email: string | null;
-  photo_url: string;
-  overriden_photo_url: string | null;
+  has_custom_photo: boolean;
   is_superuser: boolean;
   is_staff: boolean;
   hide_profile: boolean;


### PR DESCRIPTION
> [!NOTE]
> 🤖 **gpt-6-astra implementing on behalf of Antek**

Restore the existing eight predefined avatars for all non-guest accounts, while Gold users can additionally upload their own photo. Matches [backend-testownik #244](https://github.com/Solvro/backend-testownik/pull/244).

### Behavior

- Preserve the original DiceBear styles and name-based seed variants. Selecting a preset fetches its PNG and sends a File to the backend, not a URL.
- Personal uploads are Gold-only through `PermissionAction.UPLOAD_PROFILE_PHOTO` and the shared frontend account-level permission requirement. Basic/Silver users see only presets and reset. The backend does not need an additional tier restriction.
- Both kinds of image use POST `user/photo/`, multipart field `photo`; DELETE restores the account photo. The returned profile updates TanStack Query immediately, then JWT refresh updates the navbar avatar.
- Keep selection on failure, disable controls while saving, validate personal file type/size, and release preview URLs. The picker retains accessible selection states and smaller mobile targets.
- Use nullable `photo` and `has_custom_photo`; do not send removed URL fields. Existing visibility controls remain unchanged.

### Validation

157 tests and TypeScript pass, including Basic/Silver preset uploads, Gold file uploads, permission combinations, retry, switching back to the same file, multipart content, and auth refresh. Full ESLint, formatting and production build pass. Source review covered the permission/data flow and fixed narrow-screen avatar sizing; authenticated browser screenshots were unavailable because the local session redirects to login.

Pair with backend #244 and a supervised image worker (`python manage.py db_worker --backend images --queue-name images --no-reload`). Both PRs target `dev`; no merge or auto-merge until Antek approves.
